### PR TITLE
Performance fix for large for large result set

### DIFF
--- a/assets/scripts/src/choices.js
+++ b/assets/scripts/src/choices.js
@@ -140,7 +140,7 @@ class Choices {
     }
 
     // Create data store
-    this.store = new Store(this._scheduleRender.bind(this));
+    this.store = new Store();
 
     // State tracking
     this.initialised = false;
@@ -202,6 +202,7 @@ class Choices {
 
     // Bind methods
     this.render = this.render.bind(this);
+    this._scheduleRender = this._scheduleRender.bind(this);
 
     // Bind event handlers
     this._onFocus = this._onFocus.bind(this);
@@ -263,7 +264,7 @@ class Choices {
     // Generate input markup
     this._createInput();
     // Subscribe store to render method
-    this.store.subscribe(this.render);
+    this.store.subscribe(this._scheduleRender);
     // Render any items
     this.render();
     // Trigger event listeners
@@ -1950,11 +1951,6 @@ class Choices {
 
     // If target is something that concerns us
     if (this.containerOuter.contains(target)) {
-      // Handle button delete
-      if (target.hasAttribute('data-button')) {
-        this._handleButtonAction(activeItems, target);
-      }
-
       if (!hasActiveDropdown) {
         if (this.isTextElement) {
           if (document.activeElement !== this.input) {

--- a/assets/scripts/src/choices.js
+++ b/assets/scripts/src/choices.js
@@ -140,7 +140,7 @@ class Choices {
     }
 
     // Create data store
-    this.store = new Store(this.render);
+    this.store = new Store(this._scheduleRender.bind(this));
 
     // State tracking
     this.initialised = false;
@@ -175,6 +175,7 @@ class Choices {
 
     this.highlightPosition = 0;
     this.canSearch = this.config.searchEnabled;
+    this.renderScheduled = 0;
 
     this.placeholder = false;
     if (!this.isSelectOneElement) {
@@ -479,6 +480,9 @@ class Choices {
    * @private
    */
   render() {
+    // cancel any scheduled render
+    this._cancelScheduledRender();
+
     this.currentState = this.store.getState();
 
     // Only render if our state has actually changed
@@ -1135,6 +1139,31 @@ class Choices {
   /* =============================================
   =                Private functions            =
   ============================================= */
+
+  /**
+   * Cancel the scheduled render
+   */
+  _cancelScheduledRender() {
+    if (this.renderScheduled === 0) {
+      return;
+    }
+    window.cancelAnimationFrame(this.renderScheduled);
+    this.renderScheduled = 0;
+  }
+
+  /**
+   * Schedule a render on the next animation frame
+   */
+  _scheduleRender() {
+    // render was already scheduled so aborting
+    if (this.renderScheduled !== 0) {
+      return;
+    }
+    this.renderScheduled = window.requestAnimationFrame(() => {
+      this.renderScheduled = 0;
+      this.render();
+    });
+  }
 
   /**
    * Call change callback

--- a/assets/scripts/src/choices.js
+++ b/assets/scripts/src/choices.js
@@ -321,6 +321,8 @@ class Choices {
     // Nullify instance-specific data
     this.config.templates = null;
 
+    this._cancelScheduledRender();
+
     // Uninitialise
     this.initialised = false;
   }

--- a/assets/scripts/src/lib/polyfills.js
+++ b/assets/scripts/src/lib/polyfills.js
@@ -127,4 +127,29 @@
   CustomEvent.prototype = window.Event.prototype;
 
   window.CustomEvent = CustomEvent;
+
+  (function() {
+      var lastTime = 0;
+      var vendors = ['ms', 'moz', 'webkit', 'o'];
+      for(var x = 0; x < vendors.length && !window.requestAnimationFrame; ++x) {
+          window.requestAnimationFrame = window[vendors[x]+'RequestAnimationFrame'];
+          window.cancelAnimationFrame = window[vendors[x]+'CancelAnimationFrame'] 
+                                    || window[vendors[x]+'CancelRequestAnimationFrame'];
+      }
+  
+      if (!window.requestAnimationFrame)
+          window.requestAnimationFrame = function(callback, element) {
+              var currTime = new Date().getTime();
+              var timeToCall = Math.max(0, 16 - (currTime - lastTime));
+              var id = window.setTimeout(function() { callback(currTime + timeToCall); }, 
+                timeToCall);
+              lastTime = currTime + timeToCall;
+              return id;
+          };
+  
+      if (!window.cancelAnimationFrame)
+          window.cancelAnimationFrame = function(id) {
+              clearTimeout(id);
+          };
+  }());
 }());

--- a/tests/spec/choices_spec.js
+++ b/tests/spec/choices_spec.js
@@ -193,6 +193,8 @@ describe('Choices', () => {
         ctrlKey: false
       });
 
+      this.choices.render();
+
       expect(this.choices.currentState.items[0].value).toContain(this.choices.input.value);
     });
 
@@ -243,6 +245,8 @@ describe('Choices', () => {
         ctrlKey: false
       });
 
+      this.choices.render();
+
       const lastItem = this.choices.currentState.items[this.choices.currentState.items.length - 1];
 
       expect(lastItem.value).toEqual('josh@joshuajohnson.co.uk');
@@ -263,6 +267,8 @@ describe('Choices', () => {
         keyCode: 13,
         ctrlKey: false
       });
+
+      this.choices.render();
 
       const lastItem = this.choices.currentState.items[this.choices.currentState.items.length - 1];
 
@@ -358,6 +364,8 @@ describe('Choices', () => {
         ctrlKey: false,
         preventDefault: () => {}
       });
+
+      this.choices.render();
 
       expect(this.choices.currentState.items.length).toBe(2);
     });
@@ -840,6 +848,7 @@ describe('Choices', () => {
         }, ]
       }], 'value', 'label');
 
+      this.choices.render();
 
       const groups = this.choices.currentState.groups;
       const choices = this.choices.currentState.choices;
@@ -859,6 +868,7 @@ describe('Choices', () => {
         value: ''
       }], 'value', 'label', true);
 
+      this.choices.render();
 
       const choices = this.choices.currentState.choices;
       expect(choices[0].value).toEqual('one');
@@ -867,6 +877,8 @@ describe('Choices', () => {
 
     it('should handle clearStore()', function() {
       this.choices.clearStore();
+
+      this.choices.render();
 
       expect(this.choices.currentState.items).toEqual([]);
       expect(this.choices.currentState.choices).toEqual([]);


### PR DESCRIPTION
From @Remcoman:

> Rendering now occurs after one animation frame to prevent spamming of the render function.
You can still call render manually to cancel the scheduled rendering.
>
> This should resolve #173